### PR TITLE
Implement admin mode for activity registration controls

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,9 +5,11 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+import json
 import os
 from pathlib import Path
 
@@ -18,6 +20,32 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def load_teacher_credentials() -> dict:
+    teachers_path = current_dir / "teachers.json"
+    with open(teachers_path, "r", encoding="utf-8") as file:
+        return json.load(file)
+
+
+teacher_credentials = load_teacher_credentials()
+
+
+def is_valid_teacher(username: str, password: str) -> bool:
+    return teacher_credentials.get(username) == password
+
+
+def ensure_teacher_access(username: str | None, password: str | None) -> None:
+    if not username or not password or not is_valid_teacher(username, password):
+        raise HTTPException(
+            status_code=403,
+            detail="Only logged-in teachers can register or unregister students"
+        )
 
 # In-memory activity database
 activities = {
@@ -88,9 +116,24 @@ def get_activities():
     return activities
 
 
+@app.post("/admin/login")
+def teacher_login(payload: LoginRequest):
+    if not is_valid_teacher(payload.username, payload.password):
+        raise HTTPException(status_code=401, detail="Invalid teacher credentials")
+
+    return {"message": "Teacher login successful", "username": payload.username}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(
+    activity_name: str,
+    email: str,
+    x_admin_username: str | None = Header(default=None),
+    x_admin_password: str | None = Header(default=None)
+):
     """Sign up a student for an activity"""
+    ensure_teacher_access(x_admin_username, x_admin_password)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +154,15 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(
+    activity_name: str,
+    email: str,
+    x_admin_username: str | None = Header(default=None),
+    x_admin_password: str | None = Header(default=None)
+):
     """Unregister a student from an activity"""
+    ensure_teacher_access(x_admin_username, x_admin_password)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,49 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const adminRequiredMessage = document.getElementById("admin-required-message");
+  const userMenuButton = document.getElementById("user-menu-button");
+  const userMenuPanel = document.getElementById("user-menu-panel");
+  const authStatus = document.getElementById("auth-status");
+  const loginButton = document.getElementById("login-button");
+  const logoutButton = document.getElementById("logout-button");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const cancelLogin = document.getElementById("cancel-login");
+
+  let adminAuth = null;
+
+  function updateTeacherModeUI() {
+    const isTeacherMode = Boolean(adminAuth);
+    signupForm.classList.toggle("hidden", !isTeacherMode);
+    adminRequiredMessage.classList.toggle("hidden", isTeacherMode);
+    loginButton.classList.toggle("hidden", isTeacherMode);
+    logoutButton.classList.toggle("hidden", !isTeacherMode);
+    authStatus.textContent = isTeacherMode
+      ? `Teacher logged in: ${adminAuth.username}`
+      : "Student view";
+  }
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function getAdminHeaders() {
+    if (!adminAuth) {
+      return {};
+    }
+
+    return {
+      "X-Admin-Username": adminAuth.username,
+      "X-Admin-Password": adminAuth.password,
+    };
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -10,8 +53,11 @@ document.addEventListener("DOMContentLoaded", () => {
       const response = await fetch("/activities");
       const activities = await response.json();
 
+      const isTeacherMode = Boolean(adminAuth);
+
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +76,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        isTeacherMode
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">Remove</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +119,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!adminAuth) {
+      showMessage("Teacher login is required", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,32 +135,22 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: getAdminHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -113,6 +158,11 @@ document.addEventListener("DOMContentLoaded", () => {
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!adminAuth) {
+      showMessage("Teacher login is required", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -124,37 +174,89 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: getAdminHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userMenuButton.addEventListener("click", () => {
+    userMenuPanel.classList.toggle("hidden");
+  });
+
+  loginButton.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    userMenuPanel.classList.add("hidden");
+  });
+
+  cancelLogin.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  logoutButton.addEventListener("click", () => {
+    adminAuth = null;
+    updateTeacherModeUI();
+    fetchActivities();
+    userMenuPanel.classList.add("hidden");
+    showMessage("Logged out", "info");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("teacher-username").value.trim();
+    const password = document.getElementById("teacher-password").value;
+
+    try {
+      const response = await fetch("/admin/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        adminAuth = { username, password };
+        updateTeacherModeUI();
+        loginModal.classList.add("hidden");
+        loginForm.reset();
+        showMessage(result.message, "success");
+        fetchActivities();
+      } else {
+        showMessage(result.detail || "Login failed", "error");
+      }
+    } catch (error) {
+      showMessage("Failed to login. Please try again.", "error");
+      console.error("Error during login:", error);
+    }
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!userMenuPanel.contains(event.target) && !userMenuButton.contains(event.target)) {
+      userMenuPanel.classList.add("hidden");
+    }
+  });
+
   // Initialize app
+  updateTeacherModeUI();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,19 @@
   </head>
   <body>
     <header>
+      <div class="user-menu-wrapper">
+        <button id="user-menu-button" class="icon-button" aria-label="User menu" title="User menu">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="8" r="4"></circle>
+            <path d="M4 21c0-4.4 3.6-8 8-8s8 3.6 8 8"></path>
+          </svg>
+        </button>
+        <div id="user-menu-panel" class="user-menu-panel hidden">
+          <p id="auth-status">Student view</p>
+          <button id="login-button" type="button">Login as Teacher</button>
+          <button id="logout-button" type="button" class="hidden secondary">Logout</button>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -23,6 +36,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="admin-required-message" class="info-message">
+          Teacher login is required to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -44,6 +60,26 @@
     <footer>
       <p>&copy; 2026 Mergington High School</p>
     </footer>
+
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-content">
+        <h3 id="login-title">Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="teacher-username">Username:</label>
+            <input type="text" id="teacher-username" required placeholder="teacher username" />
+          </div>
+          <div class="form-group">
+            <label for="teacher-password">Password:</label>
+            <input type="password" id="teacher-password" required placeholder="password" />
+          </div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button id="cancel-login" type="button" class="secondary">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,69 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+.user-menu-wrapper {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+.icon-button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  background-color: rgba(255, 255, 255, 0.15);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.icon-button svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: #ffffff;
+  stroke-width: 2;
+}
+
+.icon-button:hover {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+.user-menu-panel {
+  position: absolute;
+  top: 45px;
+  right: 0;
+  width: 220px;
+  background-color: #ffffff;
+  color: #333;
+  padding: 12px;
+  border-radius: 5px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  z-index: 20;
+}
+
+.user-menu-panel p {
+  margin-bottom: 10px;
+  font-size: 14px;
+}
+
+.user-menu-panel button {
+  width: 100%;
+}
+
+.user-menu-panel button + button {
+  margin-top: 8px;
 }
 
 header h1 {
@@ -162,6 +219,55 @@ button {
 
 button:hover {
   background-color: #3949ab;
+}
+
+.secondary {
+  background-color: #eceff1;
+  color: #263238;
+}
+
+.secondary:hover {
+  background-color: #cfd8dc;
+}
+
+.info-message {
+  margin-bottom: 12px;
+  background-color: #e3f2fd;
+  border: 1px solid #90caf9;
+  color: #0d47a1;
+  border-radius: 4px;
+  padding: 10px;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal-content {
+  width: min(420px, calc(100% - 24px));
+  background-color: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.3);
+}
+
+.modal-content h3 {
+  margin-bottom: 15px;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.modal-actions button {
+  flex: 1;
 }
 
 .message {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+{
+  "teacher.alex": "Teach2026!",
+  "teacher.jamie": "Mergington#1"
+}


### PR DESCRIPTION
## Summary
- add teacher login endpoint and credentials file (`src/teachers.json`)
- restrict activity signup/unregister actions to authenticated teachers
- add UI user icon/menu with teacher login modal
- keep student view read-only for participant lists

## Validation
- `GET /activities` returns 200
- signup without teacher auth returns 403
- `POST /admin/login` with valid credentials returns 200
- signup/unregister with teacher headers returns 200

Closes #5